### PR TITLE
perf: minimize number of chunks

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,23 @@ function createConfig(format, target) {
       dir,
       entryFileNames: `[name].min.js`,
       chunkFileNames: `rxjs-shared.min.js`,
+      manualChunks: (id, { getModuleInfo }) => {
+        if (getModuleInfo(id).isEntry) {
+          return;
+        }
+        const indexOfNodeModules = id.indexOf("/node_modules/");
+        if (indexOfNodeModules >= 0) {
+          // we want to place 'rxjs/testing' code in a separate chunk, because it is used mainly for tests
+          if (id.indexOf("/internal/testing/", indexOfNodeModules) > 0) {
+            return "internal/testing";
+          }
+          // everything else goes into a single separate chunk
+          // ajax, fetch, sockets are too small to separate them similar to 'rxjs/testing'.
+          else if (id.indexOf("/internal/", indexOfNodeModules) > 0) {
+            return "internal";
+          }
+        }
+      },
       format,
       banner: `/* rxjs@${dependencyVersion} */`,
     },


### PR DESCRIPTION
Previously we had 8 shared chunks (see image at the left below) created in a way that 7 of them were always been downloads if user downloads let's say `rxjs.min.js` or `rsjx-operators.min.js`. That occupies all network connections of the browsers, resulting in a higher overall loading time. Now we have only 1 shared chunk, except for `rxjs/testing`, for which 2 chunks will be downloaded.

Before | After
------------ | -------------
<img width="345" alt="Previous separation to chunks" src="https://user-images.githubusercontent.com/7450378/128773563-9b8138a5-382d-47a6-ae01-81b111a01790.png"> | <img width="356" alt="New separation to chunks" src="https://user-images.githubusercontent.com/7450378/128773798-f944bc6e-411d-490f-b002-1b72b5a24b3b.png"> <br/><br/>`rxjs-shared.min.js` is used by all entrypoints and contains basically everything from rxjs and its modules.<br/>`rxjs-shared2.min.js` is used only by `rxjs/testing`.

This MR does not changed exports of `pubic` bundles (`rxjs.min.js`, `rxjs-operators.min.js`, etc.) and thus can be considered as a semver-patch change.